### PR TITLE
Create Swift package manifest

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,18 @@
+// swift-tools-version:5.3
+import PackageDescription
+
+let package = Package(
+    name: "LRNotificationObserver",
+    products: [
+        .library(
+            name: "LRNotificationObserver",
+            targets: ["LRNotificationObserver"]),
+    ],
+    dependencies: [],
+    targets: [
+        .target(
+            name: "LRNotificationObserver",
+            path: "LRNotificationObserver",
+            publicHeadersPath: ""),
+    ]
+)


### PR DESCRIPTION
This will make `LRNotificationObserver` usable via Swift Package Manager.